### PR TITLE
Update move(), move_ip() to be same with the line implementation

### DIFF
--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -319,8 +319,9 @@ pg_circle_collideswith(pgCircleObject *self, PyObject *arg)
     else if (PySequence_Check(arg)) {
         double x, y;
         if (!pg_TwoDoublesFromObj(arg, &x, &y)) {
-            return RAISE(PyExc_TypeError,
-                         "Invalid point argument, must be a sequence of 2 numbers");
+            return RAISE(
+                PyExc_TypeError,
+                "Invalid point argument, must be a sequence of 2 numbers");
         }
         result = pgCollision_CirclePoint(&self->circle, x, y);
     }
@@ -359,70 +360,57 @@ pg_circle_update(pgCircleObject *self, PyObject *const *args, Py_ssize_t nargs)
 static PyObject *
 pg_circle_move(pgCircleObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
-    double x = 0, y = 0;
-    switch (nargs) {
-        case 1:
-            if (PySequence_Check(args[0])) {
-                if (!pg_TwoDoublesFromObj(args[0], &x, &y)) {
-                    return RAISE(PyExc_TypeError,
-                                 "Invalid arguments, must be a sequence of 2 "
-                                 "numbers");
-                }
-            }
-            else if (!pg_DoubleFromObj(args[0], &x)) {
-                return RAISE(PyExc_TypeError, "Circle.move numeric values");
-            }
-            break;
-        case 2:
-            if (!pg_DoubleFromObj(args[0], &x) ||
-                !pg_DoubleFromObj(args[1], &y)) {
-                return RAISE(PyExc_TypeError,
-                             "Invalid arguments, must be 2 numbers");
-            }
-            break;
-        default:
-            return RAISE(PyExc_TypeError,
-                         "Circle.move requires 1 or 2 numbers");
+    double Dx = 0, Dy = 0;
+
+    if (nargs == 1) {
+        if (!pg_TwoDoublesFromObj(args[0], &Dx, &Dy)) {
+            goto error;
+        }
+    }
+    else if (nargs == 2) {
+        if (!pg_DoubleFromObj(args[0], &Dx) ||
+            !pg_DoubleFromObj(args[1], &Dy)) {
+            goto error;
+        }
+    }
+    else {
+        goto error;
     }
 
-    return pgCircle_New3(self->circle.x + x, self->circle.y + y,
+    return pgCircle_New3(self->circle.x + Dx, self->circle.y + Dy,
                          self->circle.r);
+error:
+    return RAISE(PyExc_TypeError, "move requires a pair of numbers");
 }
 
 static PyObject *
 pg_circle_move_ip(pgCircleObject *self, PyObject *const *args,
                   Py_ssize_t nargs)
 {
-    double x = 0, y = 0;
-    switch (nargs) {
-        case 1:
-            if (PySequence_Check(args[0])) {
-                if (!pg_TwoDoublesFromObj(args[0], &x, &y)) {
-                    return RAISE(PyExc_TypeError,
-                                 "Invalid arguments, must be a sequence of 2 "
-                                 "numbers");
-                }
-            }
-            else if (!pg_DoubleFromObj(args[0], &x)) {
-                return RAISE(PyExc_TypeError, "Circle.move_ip numeric values");
-            }
-            break;
-        case 2:
-            if (!pg_DoubleFromObj(args[0], &x) ||
-                !pg_DoubleFromObj(args[1], &y)) {
-                return RAISE(PyExc_TypeError,
-                             "Invalid arguments, must be 2 numbers");
-            }
-            break;
-        default:
-            return RAISE(PyExc_TypeError,
-                         "Circle.move_ip requires 1 or 2 numbers");
+    double Dx = 0, Dy = 0;
+
+    if (nargs == 1) {
+        if (!pg_TwoDoublesFromObj(args[0], &Dx, &Dy)) {
+            goto error;
+        }
+    }
+    else if (nargs == 2) {
+        if (!pg_DoubleFromObj(args[0], &Dx) ||
+            !pg_DoubleFromObj(args[1], &Dy)) {
+            goto error;
+        }
+    }
+    else {
+        goto error;
     }
 
-    self->circle.x += x;
-    self->circle.y += y;
+    self->circle.x += Dx;
+    self->circle.y += Dy;
 
     Py_RETURN_NONE;
+
+error:
+    return RAISE(PyExc_TypeError, "move_ip requires a pair of numbers");
 }
 
 static struct PyMethodDef pg_circle_methods[] = {

--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -377,8 +377,8 @@ pg_circle_move(pgCircleObject *self, PyObject *const *args, Py_ssize_t nargs)
         goto error;
     }
 
-    return pgCircle_New3(self->circle.x + Dx, self->circle.y + Dy,
-                         self->circle.r);
+    return _pg_circle_subtype_new3(Py_TYPE(self), self->circle.x + Dx,
+                                   self->circle.y + Dy, self->circle.r);
 error:
     return RAISE(PyExc_TypeError, "move requires a pair of numbers");
 }


### PR DESCRIPTION
Made code clearer, more compact and in line with the line implementation (pun not intended).
After discussions on discord we decided to remove the (circle only) functionality to support a single argument in move/move_ip. This is no longer a thing.