### PR TITLE
Add new functions for safe and fast tuple generation

### DIFF
--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -561,7 +561,7 @@ pg_circle_setr_sqr(pgCircleObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_circle_getcenter(pgCircleObject *self, void *closure)
 {
-    return Py_BuildValue("(dd)", self->circle.x, self->circle.y);
+    return pg_TupleFromDoublePair(self->circle.x, self->circle.y);
 }
 
 static int
@@ -663,8 +663,8 @@ static PyGetSetDef pg_circle_getsets[] = {
      NULL},
     {"d", (getter)pg_circle_getdiameter, (setter)pg_circle_setdiameter, NULL,
      NULL},
-    {"diameter", (getter)pg_circle_getdiameter, (setter)pg_circle_setdiameter, NULL,
-     NULL},
+    {"diameter", (getter)pg_circle_getdiameter, (setter)pg_circle_setdiameter,
+     NULL, NULL},
     {"center", (getter)pg_circle_getcenter, (setter)pg_circle_setcenter, NULL,
      NULL},
     {"area", (getter)pg_circle_getarea, (setter)pg_circle_setarea, NULL, NULL},

--- a/src_c/line.c
+++ b/src_c/line.c
@@ -231,7 +231,8 @@ pg_line_copy(pgLineObject *self, PyObject *_null)
 }
 
 static PyObject *
-pg_line_is_parallel(pgLineObject *self, PyObject *const *args, Py_ssize_t nargs)
+pg_line_is_parallel(pgLineObject *self, PyObject *const *args,
+                    Py_ssize_t nargs)
 {
     pgLineBase other_line;
 
@@ -308,8 +309,8 @@ pg_line_raycast(pgLineObject *self, PyObject *const *args, Py_ssize_t nargs)
         Py_RETURN_NONE;
     }
     // construct the return with this formula: A+tB
-    return Py_BuildValue(
-        "(dd)", self->line.x1 + record * (self->line.x2 - self->line.x1),
+    return pg_TupleFromDoublePair(
+        self->line.x1 + record * (self->line.x2 - self->line.x1),
         self->line.y1 + record * (self->line.y2 - self->line.y1));
 }
 
@@ -872,13 +873,7 @@ __LINE_GETSET_NAME(y2)
 static PyObject *
 pg_line_geta(pgLineObject *self, void *closure)
 {
-    PyObject *tup = PyTuple_New(2);
-    if (!tup) {
-        return PyErr_NoMemory();
-    }
-    PyTuple_SET_ITEM(tup, 0, PyFloat_FromDouble(self->line.x1));
-    PyTuple_SET_ITEM(tup, 1, PyFloat_FromDouble(self->line.y1));
-    return tup;
+    return pg_TupleFromDoublePair(self->line.x1, self->line.y1);
 }
 
 static int
@@ -898,13 +893,7 @@ pg_line_seta(pgLineObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_line_getb(pgLineObject *self, void *closure)
 {
-    PyObject *tup = PyTuple_New(2);
-    if (!tup) {
-        return PyErr_NoMemory();
-    }
-    PyTuple_SET_ITEM(tup, 0, PyFloat_FromDouble(self->line.x2));
-    PyTuple_SET_ITEM(tup, 1, PyFloat_FromDouble(self->line.y2));
-    return tup;
+    return pg_TupleFromDoublePair(self->line.x2, self->line.y2);
 }
 
 static int

--- a/src_c/polygon.c
+++ b/src_c/polygon.c
@@ -10,13 +10,15 @@
 static PyObject *
 _pg_polygon_vertices_aslist(pgPolygonBase *poly)
 {
-    return pg_PointList_FromArrayDouble(poly->vertices, poly->verts_num * 2);
+    return pg_PointList_FromArrayDouble(poly->vertices,
+                                        (int)poly->verts_num * 2);
 }
 
 static PyObject *
 _pg_polygon_vertices_astuple(pgPolygonBase *poly)
 {
-    return pg_PointTuple_FromArrayDouble(poly->vertices, poly->verts_num * 2);
+    return pg_PointTuple_FromArrayDouble(poly->vertices,
+                                         (int)poly->verts_num * 2);
 }
 
 static int

--- a/src_c/polygon.c
+++ b/src_c/polygon.c
@@ -8,70 +8,15 @@
 #include <math.h>
 
 static PyObject *
-pg_tuple_from_values_double(double val1, double val2)
-{
-    PyObject *tup = PyTuple_New(2);
-    if (!tup) {
-        return NULL;
-    }
-
-    PyObject *tmp = PyFloat_FromDouble(val1);
-    if (!tmp) {
-        Py_DECREF(tup);
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tup, 0, tmp);
-
-    tmp = PyFloat_FromDouble(val2);
-    if (!tmp) {
-        Py_DECREF(tup);
-        return NULL;
-    }
-    PyTuple_SET_ITEM(tup, 1, tmp);
-
-    return tup;
-}
-
-static PyObject *
 _pg_polygon_vertices_aslist(pgPolygonBase *poly)
 {
-    PyObject *list = PyList_New(poly->verts_num);
-    if (!list) {
-        return NULL;
-    }
-    Py_ssize_t i;
-
-    for (i = 0; i < poly->verts_num; i++) {
-        PyObject *tup = pg_tuple_from_values_double(poly->vertices[i * 2],
-                                                    poly->vertices[i * 2 + 1]);
-        if (!tup) {
-            Py_DECREF(list);
-            return NULL;
-        }
-        PyList_SET_ITEM(list, i, tup);
-        tup = NULL;
-    }
-    return list;
+    return pg_PointList_FromArrayDouble(poly->vertices, poly->verts_num * 2);
 }
 
 static PyObject *
 _pg_polygon_vertices_astuple(pgPolygonBase *poly)
 {
-    PyObject *vertices = PyTuple_New(poly->verts_num);
-    if (!vertices) {
-        return NULL;
-    }
-    Py_ssize_t i;
-    for (i = 0; i < poly->verts_num; i++) {
-        PyObject *tup = pg_tuple_from_values_double(poly->vertices[i * 2],
-                                                    poly->vertices[i * 2 + 1]);
-        if (!tup) {
-            Py_DECREF(vertices);
-            return NULL;
-        }
-        PyTuple_SET_ITEM(vertices, i, tup);
-    }
-    return vertices;
+    return pg_PointTuple_FromArrayDouble(poly->vertices, poly->verts_num * 2);
 }
 
 static int


### PR DESCRIPTION
This PR adds 3 new C api functions for creating tuples representing points. It also implements part of these functions to existing API (specifically the line one) to make them safer and more compact.

## Added
- **pg_TupleFromDoubles**
    Takes two doubles and returns a tuple containing two PyFloat objects on success, NULL and sets an error otherwise

- **pg_TupleFromInts** 
    Same as the last but for ints

- **pg_PointList_FromArrayDouble**
    Takes an even length double array and returns a list of points: 
`C_arr[1, 2, 3, 4, 5, 6, 7, 8] -> List((1, 2), (3, 4), (5, 6), (7, 8))`

- **pg_PointTuple_FromArrayDouble**
    Takes an even length double array and returns a tupleof points: 
`C_arr[1, 2, 3, 4, 5, 6, 7, 8] -> Tuple((1, 2), (3, 4), (5, 6), (7, 8))`

## Modified
- line `a` getter
    The getter was unsafe as it directly set the tuple items without checking that the conversion `double->PyObject *` was successful. Now with the new functions we have correct checks.

- line `b` getter
    The getter was unsafe as it directly set the tuple items without checking that the conversion `double->PyObject *` was successful. Now with the new functions we have correct checks.

- circle `center` attribute
    The getter was utilizing `Py_BuildValue`, which is slower than the new implementation while still being safe with errors.

- line `raycast` function
    Is now slightly faster because of the new function ( Demonstrated that these functions are faster than `Py_BuildValue` in an already merged pygame PR)
    
