### PR TITLE
New polygon creation method

### DIFF
--- a/benchmarks/GEOMETRY_polygon_benchmark.py
+++ b/benchmarks/GEOMETRY_polygon_benchmark.py
@@ -1,6 +1,6 @@
 from benchmark_utils import TestSuite
 
-from geometry import Polygon
+from geometry import Polygon, regular_polygon
 
 # === Tests ===
 # Each test consists of a tuple of: (name, call)
@@ -15,6 +15,7 @@ GLOB = {
     "Polygon": Polygon,
     "po3": Polygon([(50, 50), (50, 100), (70, 55)]),
     "po4": Polygon([(50, 50), (50, 100), (70, 55), (100, 23)]),
+    "po100": regular_polygon(100, (50, 50), 50),
     "p1_i": (50, 50),
     "p2_i": (50, 100),
     "p3_i": (70, 55),
@@ -47,11 +48,23 @@ getters_tests = [
     ("verts_num 3", "po3.verts_num"),
     ("vertices 4", "po4.vertices"),
     ("verts_num 4", "po4.verts_num"),
+    ("c_x 3", "po3.c_x"),
+    ("c_y 3", "po3.c_y"),
+    ("c_x 4", "po4.c_x"),
+    ("c_y 4", "po4.c_y"),
+    ("center 3", "po3.center"),
+    ("center 4", "po4.center"),
 ]
 
 setters_tests = [
-    ("vertices int", "po4.vertices = [p1_i, p2_i, p3_i, p4_i]"),
-    ("vertices float", "po4.vertices = [p1_f, p2_f, p3_f, p4_f]"),
+    # ("vertices int", "po4.vertices = [p1_i, p2_i, p3_i, p4_i]"),
+    # ("vertices float", "po4.vertices = [p1_f, p2_f, p3_f, p4_f]"),
+    ("center int", "po4.center = p1_i"),
+    ("center float", "po4.center = p1_f"),
+    ("c_x int", "po4.c_x = 50"),
+    ("c_y int", "po4.c_y = 50"),
+    ("c_x float", "po4.c_x = 50.0"),
+    ("c_y float", "po4.c_y = 50.0"),
 ]
 
 copy_tests = [
@@ -59,10 +72,31 @@ copy_tests = [
     ("copy 4", "po4.copy()"),
 ]
 
+move_tests = [
+    ("move 100 tuple int", "po100.move((10, 10))"),
+    ("move 100 tuple float", "po100.move((10.0, 10.0))"),
+    ("move 100 2 int", "po100.move(10, 10)"),
+    ("move 100 2 float", "po100.move(10.0, 10.0)"),
+    ("move 100 2 int", "po100.move(10, 10)"),
+    ("move 100 2 float", "po100.move(10.0, 10.0)"),
+]
+
+move_ip_tests = [
+    ("move_ip 100 tuple int", "po100.move_ip((10, 10))"),
+    ("move_ip 100 tuple float", "po100.move_ip((10.0, 10.0))"),
+    ("move_ip 100 2 int", "po100.move_ip(10, 10)"),
+    ("move_ip 100 2 float", "po100.move_ip(10.0, 10.0)"),
+    ("move_ip 100 2 int", "po100.move_ip(10, 10)"),
+    ("move_ip 100 2 float", "po100.move_ip(10.0, 10.0)"),
+]
+
 GROUPS = [
     ("Creation", creation_tests),
     ("Attribute Getters", getters_tests),
+    ("Attribute Setters", setters_tests),
     ("Copy", copy_tests),
+    ("Move", move_tests),
+    ("Move_ip", move_ip_tests),
 ]
 
 if __name__ == "__main__":

--- a/src_c/polygon.c
+++ b/src_c/polygon.c
@@ -281,6 +281,31 @@ _pg_polygon_subtype_new2(PyTypeObject *type, double *vertices,
 }
 
 static PyObject *
+_pg_polygon_subtype_new2_transfer(PyTypeObject *type, double *vertices,
+                                  Py_ssize_t verts_num)
+{
+    pgPolygonObject *polygon_obj =
+        (pgPolygonObject *)pgPolygon_Type.tp_new(type, NULL, NULL);
+
+    if (!polygon_obj) {
+        return NULL;
+    }
+
+    if (verts_num < 3 || !vertices) {
+        /*A polygon requires 3 or more vertices*/
+        Py_DECREF(polygon_obj);
+        return NULL;
+    }
+
+    polygon_obj->polygon.vertices = vertices;
+    polygon_obj->polygon.verts_num = verts_num;
+
+    _set_polygon_center_coords(&(polygon_obj->polygon));
+
+    return (PyObject *)polygon_obj;
+}
+
+static PyObject *
 pg_polygon_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     pgPolygonObject *self = (pgPolygonObject *)type->tp_alloc(type, 0);
@@ -380,13 +405,13 @@ pg_polygon_move(pgPolygonObject *self, PyObject *const *args, Py_ssize_t nargs)
         verts[i2 + 1] += Dy;
     }
 
-    PyObject *tmp = _pg_polygon_subtype_new2(Py_TYPE(self), verts,
-                                             self->polygon.verts_num);
+    PyObject *tmp = _pg_polygon_subtype_new2_transfer(Py_TYPE(self), verts,
+                                                      self->polygon.verts_num);
     if (!tmp) {
         PyMem_Free(verts);
         return NULL;
     }
-    PyMem_Free(verts);
+
     return tmp;
 error:
     return RAISE(PyExc_TypeError, "move requires a pair of numbers");


### PR DESCRIPTION
This PR adds some more polygon benchmarks and a new function that improves performance for the polygon move functions and for any future function that returns a copy of the original polygon with updated vertices.
This is because of the fact that in those kinds of functions we allocate new memory that we use for vertices manipulation already, so it doesn't make sense to create new memory again and discard the other. All of this saves an extra memory allocation and a memcpy, saving about 20-25%.
![](https://cdn.discordapp.com/attachments/1002836330482511943/1024682648918044733/unknown.png)
