### PR TITLE
Disallowed degenerate(radius=0) circles + better error messages

### DIFF
--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -55,11 +55,12 @@ pg_circle_dealloc(pgCircleObject *self)
 static int
 _pg_circle_set_radius(PyObject *value, pgCircleBase *circle)
 {
-    double tmp = 0;
-    if (!pg_DoubleFromObj(value, &tmp) || tmp < 0)
+    double radius = 0;
+    if (!pg_DoubleFromObj(value, &radius) || radius <= 0) {
         return 0;
-    circle->r = tmp;
-    circle->r_sqr = tmp * tmp;
+    }
+    circle->r = radius;
+    circle->r_sqr = radius * radius;
     return 1;
 }
 
@@ -574,16 +575,24 @@ pg_circle_getr(pgCircleObject *self, void *closure)
 static int
 pg_circle_setr(pgCircleObject *self, PyObject *value, void *closure)
 {
-    double val;
+    double radius;
+
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
-    if (!pg_DoubleFromObj(value, &val) || val < 0) {
-        PyErr_SetString(PyExc_TypeError, "Expected a positive number");
+    if (!pg_DoubleFromObj(value, &radius)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Invalid type for radius, must be numeric");
         return -1;
     }
 
-    self->circle.r = val;
-    self->circle.r_sqr = val * val;
+    if (radius <= 0) {
+        PyErr_SetString(PyExc_ValueError, "Invalid radius value, must be > 0");
+        return -1;
+    }
+
+    self->circle.r = radius;
+    self->circle.r_sqr = radius * radius;
+
     return 0;
 }
 
@@ -596,16 +605,25 @@ pg_circle_getr_sqr(pgCircleObject *self, void *closure)
 static int
 pg_circle_setr_sqr(pgCircleObject *self, PyObject *value, void *closure)
 {
-    double val;
+    double radius_squared;
+
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
 
-    if (!pg_DoubleFromObj(value, &val) || val < 0) {
-        PyErr_SetString(PyExc_TypeError, "Expected a positive number");
+    if (!pg_DoubleFromObj(value, &radius_squared)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Invalid type for radius squared, must be numeric");
         return -1;
     }
 
-    self->circle.r_sqr = val;
-    self->circle.r = sqrt(val);
+    if (radius_squared <= 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Invalid radius squared value, must be > 0");
+        return -1;
+    }
+
+    self->circle.r_sqr = radius_squared;
+    self->circle.r = sqrt(radius_squared);
+
     return 0;
 }
 
@@ -635,14 +653,24 @@ pg_circle_getarea(pgCircleObject *self, void *closure)
 static int
 pg_circle_setarea(pgCircleObject *self, PyObject *value, void *closure)
 {
-    double val;
+    double area;
+
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
-    if (!pg_DoubleFromObj(value, &val) || val <= 0) {
-        PyErr_SetString(PyExc_TypeError, "Expected a positive number");
+
+    if (!pg_DoubleFromObj(value, &area)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Invalid type for area, must be numeric");
         return -1;
     }
-    self->circle.r_sqr = val / PI;
+
+    if (area <= 0) {
+        PyErr_SetString(PyExc_ValueError, "Invalid area value, must be > 0");
+        return -1;
+    }
+
+    self->circle.r_sqr = area / PI;
     self->circle.r = sqrt(self->circle.r_sqr);
+
     return 0;
 }
 
@@ -656,13 +684,23 @@ static int
 pg_circle_setcircumference(pgCircleObject *self, PyObject *value,
                            void *closure)
 {
-    double val;
+    double circumference;
+
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
-    if (!pg_DoubleFromObj(value, &val) || val <= 0) {
-        PyErr_SetString(PyExc_TypeError, "Expected a positive number");
+
+    if (!pg_DoubleFromObj(value, &circumference)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Invalid type for circumference, must be numeric");
         return -1;
     }
-    self->circle.r = val / TAU;
+
+    if (circumference <= 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Invalid circumference value, must be > 0");
+        return -1;
+    }
+
+    self->circle.r = circumference / TAU;
     self->circle.r_sqr = self->circle.r * self->circle.r;
 
     return 0;
@@ -677,14 +715,25 @@ pg_circle_getdiameter(pgCircleObject *self, void *closure)
 static int
 pg_circle_setdiameter(pgCircleObject *self, PyObject *value, void *closure)
 {
-    double val;
+    double diameter;
+
     DEL_ATTR_NOT_SUPPORTED_CHECK_NO_NAME(value);
-    if (!pg_DoubleFromObj(value, &val) || val <= 0) {
-        PyErr_SetString(PyExc_TypeError, "Expected a positive number");
+
+    if (!pg_DoubleFromObj(value, &diameter)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Invalid type for diameter, must be numeric");
         return -1;
     }
-    self->circle.r = val / 2;
+
+    if (diameter <= 0) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Invalid diameter value, must be > 0");
+        return -1;
+    }
+
+    self->circle.r = diameter / 2;
     self->circle.r_sqr = self->circle.r * self->circle.r;
+
     return 0;
 }
 

--- a/test/test_circle.py
+++ b/test/test_circle.py
@@ -178,8 +178,12 @@ class CircleTypeTest(unittest.TestCase):
         """Ensures the r attribute handles invalid values correctly."""
         c = Circle(0, 0, 1)
 
-        for value in (None, [], "1", (1,), [1, 2, 3], -1):
+        for value in (None, [], "1", (1,), [1, 2, 3]):
             with self.assertRaises(TypeError):
+                c.r = value
+
+        for value in (-10.3234, -1, 0, 0.0):
+            with self.assertRaises(ValueError):
                 c.r = value
 
     def test_r__del(self):
@@ -301,8 +305,12 @@ class CircleTypeTest(unittest.TestCase):
         """Ensures the area handles invalid values correctly."""
         c = Circle(0, 0, 1)
 
-        for value in (None, [], "1", (1,), [1, 2, 3], -1):
+        for value in (None, [], "1", (1,), [1, 2, 3]):
             with self.assertRaises(TypeError):
+                c.area = value
+
+        for value in (-10.3234, -1, 0, 0.0):
+            with self.assertRaises(ValueError):
                 c.area = value
 
     def test_area_del(self):
@@ -332,8 +340,12 @@ class CircleTypeTest(unittest.TestCase):
         """Ensures the circumference handles invalid values correctly."""
         c = Circle(0, 0, 1)
 
-        for value in (None, [], "1", (1,), [1, 2, 3], -1, 0):
+        for value in (None, [], "1", (1,), [1, 2, 3]):
             with self.assertRaises(TypeError):
+                c.circumference = value
+
+        for value in (-10.3234, -1, 0, 0.0):
+            with self.assertRaises(ValueError):
                 c.circumference = value
 
     def test_circumference_del(self):
@@ -366,8 +378,12 @@ class CircleTypeTest(unittest.TestCase):
         """Ensures the diameter handles invalid values correctly."""
         c = Circle(0, 0, 1)
 
-        for value in (None, [], "1", (1,), [1, 2, 3], -1, 0):
+        for value in (None, [], "1", (1,), [1, 2, 3]):
             with self.assertRaises(TypeError):
+                c.diameter = value
+
+        for value in (-10.3234, -1, 0, 0.0):
+            with self.assertRaises(ValueError):
                 c.diameter = value
 
     def test_diameter_del(self):
@@ -409,10 +425,8 @@ class CircleTypeTest(unittest.TestCase):
 
     def test_bool(self):
         c = Circle(10, 10, 4)
-        c2 = Circle(10, 10, 0)
 
         self.assertTrue(c, "Expected c to be True as radius is > 0")
-        self.assertFalse(c2, "Expected c to be False as radius is != 0")
 
     def test_collidecircle_argtype(self):
         """tests if the function correctly handles incorrect types as parameters"""


### PR DESCRIPTION
Before this PR you could do:

```Python
circle = Circle((10, 10), 4)
circle.r = 0
circle.d = 0
circle.circumference = 0
circle.area = 0
```
This is no more.

Another issue this PR tries to solve is attribute assignment error messages. These were very imprecise and did not distinguish between a wrong type being passed and  a wrong value. It now raises `TypeError` on wrong type and `ValueError` on wrong value ( <= 0 ).
