### PR TITLE
Made line.colliderect() FASTCALL

### DIFF
--- a/src_c/line.c
+++ b/src_c/line.c
@@ -405,15 +405,44 @@ pg_line_update(pgLineObject *self, PyObject *const *args, Py_ssize_t nargs)
 }
 
 static PyObject *
-pg_line_colliderect(pgLineObject *self, PyObject *args)
+pg_line_colliderect(pgLineObject *self, PyObject *const *args,
+                    Py_ssize_t nargs)
 {
-    SDL_Rect *rect, temp;
+    SDL_Rect temp;
 
-    if (!(rect = pgRect_FromObject(args, &temp))) {
-        return RAISE(PyExc_TypeError,
-                     "Line.colliderect requires a Rect or a RectLike object");
+    if (nargs == 1) {
+        SDL_Rect *tmp;
+        if (!(tmp = pgRect_FromObject(args[0], &temp))) {
+            if (PyErr_Occurred())
+                return NULL;
+            else
+                return RAISE(PyExc_TypeError,
+                             "Invalid rect, all 4 fields must be numeric");
+        }
+        return PyBool_FromLong(pgCollision_RectLine(tmp, &self->line));
     }
-    return PyBool_FromLong(pgCollision_RectLine(rect, &self->line));
+    else if (nargs == 2) {
+        if (!pg_TwoIntsFromObj(args[0], &temp.x, &temp.y) ||
+            !pg_TwoIntsFromObj(args[1], &temp.w, &temp.h)) {
+            return RAISE(PyExc_TypeError,
+                         "Invalid rect, all 4 fields must be numeric");
+        }
+    }
+    else if (nargs == 4) {
+        if (!pg_IntFromObj(args[0], &temp.x) ||
+            !pg_IntFromObj(args[1], &temp.y) ||
+            !pg_IntFromObj(args[2], &temp.w) ||
+            !pg_IntFromObj(args[3], &temp.h)) {
+            return RAISE(PyExc_TypeError,
+                         "Invalid rect, all 4 fields must be numeric");
+        }
+    }
+    else {
+        return RAISE(PyExc_TypeError,
+                     "Invalid arguments number, must be 1, 2 or 4");
+    }
+
+    return PyBool_FromLong(pgCollision_RectLine(&temp, &self->line));
 }
 
 static PyObject *
@@ -538,7 +567,7 @@ static struct PyMethodDef pg_line_methods[] = {
     {"collideline", (PyCFunction)pg_line_collideline, METH_FASTCALL, NULL},
     {"collidepoint", (PyCFunction)pg_line_collidepoint, METH_FASTCALL, NULL},
     {"collidecircle", (PyCFunction)pg_line_collidecircle, METH_FASTCALL, NULL},
-    {"colliderect", (PyCFunction)pg_line_colliderect, METH_VARARGS, NULL},
+    {"colliderect", (PyCFunction)pg_line_colliderect, METH_FASTCALL, NULL},
     {"collideswith", (PyCFunction)pg_line_collideswith, METH_O, NULL},
     {"as_rect", (PyCFunction)pg_line_as_rect, METH_NOARGS, NULL},
     {"update", (PyCFunction)pg_line_update, METH_FASTCALL, NULL},


### PR DESCRIPTION
We were wasting a lot of performance by not having line.colliderect() FASTCALL. With this i see a 36% performance improvement overall.

The results:

OLD:
```
COLLISION: RECT
==================================================
|             Name             |  Total  |  Mean  |  Std Dev  |
|------------------------------|---------|--------|-----------|
|            C rect            | 590.56  | 59.06  |   1.15    |
|           NC rect            | 610.32  | 61.03  |    2.5    |
|         inside rect          |  587.4  | 58.74  |   0.91    |
|           C 4 int            | 1260.65 | 126.06 |   2.64    |
|           NC 4 int           | 1255.34 | 125.53 |   1.54    |
|         inside 4 int         | 1251.77 | 125.18 |   1.01    |
|          C 4 float           | 1131.43 | 113.14 |   2.04    |
|          NC 4 float          | 1150.34 | 115.03 |   3.87    |
|        inside 4 float        | 1170.5  | 117.05 |   2.79    |
|        C 1 tup 4 int         | 1168.05 | 116.8  |   1.25    |
|        NC 1 tup 4 int        | 1186.27 | 118.63 |   2.77    |
|      inside 1 tup 4 int      | 1195.02 | 119.5  |   4.48    |
|       C 1 tup 4 float        | 1101.76 | 110.18 |   3.65    |
|       NC 1 tup 4 float       | 1066.09 | 106.61 |   0.96    |
|     inside 1 tup 4 float     | 1061.02 | 106.1  |   1.69    |
|    C 1 tup 2 subtups int     | 1310.03 |  131   |   2.39    |
|    NC 1 tup 2 subtups int    | 1323.94 | 132.39 |   1.54    |
|  inside 1 tup 2 subtups int  | 1351.99 | 135.2  |   2.81    |
|   C 1 tup 2 subtups float    | 1218.28 | 121.83 |   3.41    |
|   NC 1 tup 2 subtups float   | 1329.39 | 132.94 |   15.01   |
| inside 1 tup 2 subtups float | 1193.38 | 119.34 |   0.69    |

--------------------------------------------------
Group Mean: 111.97
Group Total: 23513.52
Group Standard Deviation: 22.81
Group Median: 118.63
```

NEW
```
COLLISION: RECT
==================================================
|             Name             |  Total  |  Mean  |  Std Dev  |
|------------------------------|---------|--------|-----------|
|            C rect            | 488.72  | 48.87  |   1.21    |
|           NC rect            | 488.99  |  48.9  |   1.81    |
|         inside rect          | 479.96  |   48   |   1.09    |
|           C 4 int            | 813.56  | 81.36  |   0.72    |
|           NC 4 int           | 820.82  | 82.08  |   1.03    |
|         inside 4 int         | 795.34  | 79.53  |   1.46    |
|          C 4 float           | 653.08  | 65.31  |   0.53    |
|          NC 4 float          | 658.75  | 65.87  |   0.64    |
|        inside 4 float        | 654.65  | 65.47  |   0.62    |
|        C 1 tup 4 int         | 915.26  | 91.53  |   0.79    |
|        NC 1 tup 4 int        | 946.23  | 94.62  |   5.03    |
|      inside 1 tup 4 int      | 927.87  | 92.79  |   1.01    |
|       C 1 tup 4 float        |  794.5  | 79.45  |   0.74    |
|       NC 1 tup 4 float       | 784.67  | 78.47  |   0.35    |
|     inside 1 tup 4 float     | 784.72  | 78.47  |   0.55    |
|    C 1 tup 2 subtups int     | 1121.18 | 112.12 |   1.76    |
|    NC 1 tup 2 subtups int    | 1124.12 | 112.41 |   1.94    |
|  inside 1 tup 2 subtups int  | 1135.09 | 113.51 |   1.89    |
|   C 1 tup 2 subtups float    | 962.82  | 96.28  |   0.67    |
|   NC 1 tup 2 subtups float   | 961.08  | 96.11  |   0.49    |
| inside 1 tup 2 subtups float | 967.85  | 96.79  |   0.84    |

--------------------------------------------------
Group Mean: 82.28
Group Total: 17279.27
Group Standard Deviation: 19.53
Group Median: 81.36
```