### PR TITLE
geometry.regular_polygon() optimization

### DIFF
--- a/src_c/geometry.c
+++ b/src_c/geometry.c
@@ -12,7 +12,7 @@ static PyObject *
 geometry_regular_polygon(PyObject *_null, PyObject *const *args,
                          Py_ssize_t nargs)
 {
-    int sides;
+    Py_ssize_t sides;
     double radius;
     double angle = 0;
     double Cx, Cy;
@@ -21,7 +21,7 @@ geometry_regular_polygon(PyObject *_null, PyObject *const *args,
         return RAISE(PyExc_TypeError,
                      "invalid number of arguments, expected 3 or 4 arguments");
     }
-    sides = PyLong_AsLong(args[0]);
+    sides = PyLong_AsSsize_t(args[0]);
     if (PyErr_Occurred()) {
         return NULL;
     }
@@ -56,7 +56,7 @@ geometry_regular_polygon(PyObject *_null, PyObject *const *args,
                      "cannot allocate memory for the polygon vertices");
     }
 
-    int loop;
+    Py_ssize_t loop;
     double fac = TAU / sides;
     for (loop = 0; loop < sides; loop++) {
         double ang = angle + fac * loop;
@@ -64,12 +64,21 @@ geometry_regular_polygon(PyObject *_null, PyObject *const *args,
         vertices[loop * 2 + 1] = Cy + radius * sin(ang);
     }
 
-    PyObject *ret = pgPolygon_New2(vertices, sides);
-    PyMem_Free(vertices);
+    pgPolygonObject *ret =
+        (pgPolygonObject *)pgPolygon_Type.tp_new(&pgPolygon_Type, NULL, NULL);
 
-    return ret;
+    if (!ret) {
+        PyMem_Free(vertices);
+        return NULL;
+    }
+
+    ret->polygon.vertices = vertices;
+    ret->polygon.verts_num = (Py_ssize_t)sides;
+    ret->polygon.c_x = Cx;
+    ret->polygon.c_y = Cy;
+
+    return (PyObject *)ret;
 }
-
 
 static PyMethodDef _pg_module_methods[] = {
     {"regular_polygon", (PyCFunction)geometry_regular_polygon, METH_FASTCALL,

--- a/src_c/geometry.c
+++ b/src_c/geometry.c
@@ -58,10 +58,27 @@ geometry_regular_polygon(PyObject *_null, PyObject *const *args,
 
     Py_ssize_t loop;
     double fac = TAU / sides;
-    for (loop = 0; loop < sides; loop++) {
-        double ang = angle + fac * loop;
-        vertices[loop * 2] = Cx + radius * cos(ang);
-        vertices[loop * 2 + 1] = Cy + radius * sin(ang);
+
+    /*If the number of sides is even, mirror the vertices*/
+    if (sides % 2 == 0) {
+        for (loop = 0; loop < sides / 2; loop++) {
+            double ang = angle + fac * loop;
+            double radi_cos_a = radius * cos(ang);
+            double radi_sin_a = radius * sin(ang);
+
+            vertices[loop * 2] = Cx + radi_cos_a;
+            vertices[loop * 2 + 1] = Cy + radi_sin_a;
+
+            vertices[sides + loop * 2] = Cx - radi_cos_a;
+            vertices[sides + loop * 2 + 1] = Cy - radi_sin_a;
+        }
+    }
+    else {
+        for (loop = 0; loop < sides; loop++) {
+            double ang = angle + fac * loop;
+            vertices[loop * 2] = Cx + radius * cos(ang);
+            vertices[loop * 2 + 1] = Cy + radius * sin(ang);
+        }
     }
 
     pgPolygonObject *ret =
@@ -73,7 +90,7 @@ geometry_regular_polygon(PyObject *_null, PyObject *const *args,
     }
 
     ret->polygon.vertices = vertices;
-    ret->polygon.verts_num = (Py_ssize_t)sides;
+    ret->polygon.verts_num = sides;
     ret->polygon.c_x = Cx;
     ret->polygon.c_y = Cy;
 

--- a/test/test_polygon.py
+++ b/test/test_polygon.py
@@ -217,11 +217,9 @@ class PolygonTypeTest(unittest.TestCase):
             ang = radang + i * fac
             radi_cos_a = radius * math.cos(ang)
             radi_sin_a = radius * math.sin(ang)
-            vertices[i] = (center[0] + radi_cos_a,
-                           center[1] + radi_sin_a)
+            vertices[i] = (center[0] + radi_cos_a, center[1] + radi_sin_a)
 
-            vertices[sides // 2 + i] = (center[0] - radi_cos_a,
-                                        center[1] - radi_sin_a)
+            vertices[sides // 2 + i] = (center[0] - radi_cos_a, center[1] - radi_sin_a)
 
         self.assertEqual(vertices_pg, vertices)
 

--- a/test/test_polygon.py
+++ b/test/test_polygon.py
@@ -209,17 +209,19 @@ class PolygonTypeTest(unittest.TestCase):
         polygon_pg = geometry.regular_polygon(sides, center, radius, angle)
         vertices_pg = polygon_pg.vertices
 
-        vertices = []
+        vertices = list(range(sides))
 
-        for i in range(sides):
-            vertices.append(
-                (
-                    center[0]
-                    + radius * math.cos(math.radians(angle) + math.pi * 2 * i / sides),
-                    center[1]
-                    + radius * math.sin(math.radians(angle) + math.pi * 2 * i / sides),
-                )
-            )
+        fac = math.tau / sides
+        radang = math.radians(angle)
+        for i in range(sides // 2):
+            ang = radang + i * fac
+            radi_cos_a = radius * math.cos(ang)
+            radi_sin_a = radius * math.sin(ang)
+            vertices[i] = (center[0] + radi_cos_a,
+                           center[1] + radi_sin_a)
+
+            vertices[sides // 2 + i] = (center[0] - radi_cos_a,
+                                        center[1] - radi_sin_a)
 
         self.assertEqual(vertices_pg, vertices)
 


### PR DESCRIPTION
I've found a little optimization due to the fact that `pgPolygonNew2` utilizes `_pg_polygon_subtype_new2`. The latter has the peculiarity to allocate new memory, copy from the input one and also has to calculate the center of the polygon, therefore having to run trough a for loop for all the vertices.

With this optimization i basically skip new memory assigment (like in `_pg_polygon_subtype_new2_transfer`) by directly assigning the already available memory and i also skip the whole memcpy step and pymemfree. I also easily skip the "running trough all the verticies" as we already know where the center of the poly should be because it's the values we passed as params to the function. 

I've also swapped all ints for Py_ssize_t(s) as it's more scalable this way and makes this work on all platform configs.

With all these changes i've seen a 9-11% perf improvement.

Edit.
I implemented a more performant path for when the function is asked to create a poly with an even number of vertices. In that case we don't need to compute all the vertices but rather half of them and mirror the rest 180° apart. this reduces the number of sin/cos by half and the number of multiplications by half. I've seen performance uplifts of up to 2X for very big polys and around 33% for squares/esagons.