### PR TITLE
Added pg_TwoDoublesFromFastcallArgs and swapped all duplicates

### DIFF
--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -269,29 +269,15 @@ static PyObject *
 pg_circle_collidepoint(pgCircleObject *self, PyObject *const *args,
                        Py_ssize_t nargs)
 {
-    double px = 0, py = 0;
+    double px, py;
 
-    if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &px, &py)) {
-            goto error;
-        }
-    }
-    else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &px) ||
-            !pg_DoubleFromObj(args[1], &py)) {
-            goto error;
-        }
-    }
-    else {
-        return RAISE(PyExc_TypeError,
-                     "Invalid arguments number, can be at most 2");
+    if (!pg_TwoDoublesFromFastcallArgs(args, nargs, &px, &py)) {
+        return RAISE(
+            PyExc_TypeError,
+            "Circle.collidepoint requires a point or PointLike object");
     }
 
     return PyBool_FromLong(pgCollision_CirclePoint(&(self->circle), px, py));
-
-error:
-    return RAISE(PyExc_TypeError,
-                 "collidepoint requires a point or PointLike object");
 }
 static PyObject *
 pg_circle_colliderect(pgCircleObject *self, PyObject *const *args,
@@ -392,57 +378,30 @@ pg_circle_update(pgCircleObject *self, PyObject *const *args, Py_ssize_t nargs)
 static PyObject *
 pg_circle_move(pgCircleObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
-    double Dx = 0, Dy = 0;
+    double Dx, Dy;
 
-    if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &Dx, &Dy)) {
-            goto error;
-        }
-    }
-    else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &Dx) ||
-            !pg_DoubleFromObj(args[1], &Dy)) {
-            goto error;
-        }
-    }
-    else {
-        goto error;
+    if (!pg_TwoDoublesFromFastcallArgs(args, nargs, &Dx, &Dy)) {
+        return RAISE(PyExc_TypeError, "move requires a pair of numbers");
     }
 
     return _pg_circle_subtype_new3(Py_TYPE(self), self->circle.x + Dx,
                                    self->circle.y + Dy, self->circle.r);
-error:
-    return RAISE(PyExc_TypeError, "move requires a pair of numbers");
 }
 
 static PyObject *
 pg_circle_move_ip(pgCircleObject *self, PyObject *const *args,
                   Py_ssize_t nargs)
 {
-    double Dx = 0, Dy = 0;
+    double Dx, Dy;
 
-    if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &Dx, &Dy)) {
-            goto error;
-        }
-    }
-    else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &Dx) ||
-            !pg_DoubleFromObj(args[1], &Dy)) {
-            goto error;
-        }
-    }
-    else {
-        goto error;
+    if (!pg_TwoDoublesFromFastcallArgs(args, nargs, &Dx, &Dy)) {
+        return RAISE(PyExc_TypeError, "move_ip requires a pair of numbers");
     }
 
     self->circle.x += Dx;
     self->circle.y += Dy;
 
     Py_RETURN_NONE;
-
-error:
-    return RAISE(PyExc_TypeError, "move_ip requires a pair of numbers");
 }
 
 static struct PyMethodDef pg_circle_methods[] = {

--- a/src_c/include/base.h
+++ b/src_c/include/base.h
@@ -251,6 +251,20 @@ pg_UintFromObjIndex(PyObject *obj, int _index, Uint32 *val)
     return result;
 }
 
+static PG_FORCE_INLINE int
+pg_TwoDoublesFromFastcallArgs(PyObject *const *args, Py_ssize_t nargs,
+                              double *val1, double *val2)
+{
+    if (nargs == 1) {
+        return pg_TwoDoublesFromObj(args[0], val1, val2);
+    }
+    else if (nargs == 2) {
+        return pg_DoubleFromObj(args[0], val1) &&
+               pg_DoubleFromObj(args[1], val2);
+    }
+    return 0;
+}
+
 // these return PyObject * on success and NULL on failure.
 
 static PG_FORCE_INLINE PyObject *

--- a/src_c/include/base.h
+++ b/src_c/include/base.h
@@ -255,12 +255,12 @@ static PG_FORCE_INLINE int
 pg_TwoDoublesFromFastcallArgs(PyObject *const *args, Py_ssize_t nargs,
                               double *val1, double *val2)
 {
-    if (nargs == 1) {
-        return pg_TwoDoublesFromObj(args[0], val1, val2);
+    if (nargs == 1 && pg_TwoDoublesFromObj(args[0], val1, val2)) {
+        return 1;
     }
-    else if (nargs == 2) {
-        return pg_DoubleFromObj(args[0], val1) &&
-               pg_DoubleFromObj(args[1], val2);
+    else if (nargs == 2 && pg_DoubleFromObj(args[0], val1) &&
+             pg_DoubleFromObj(args[1], val2)) {
+        return 1;
     }
     return 0;
 }

--- a/src_c/line.c
+++ b/src_c/line.c
@@ -347,28 +347,14 @@ static PyObject *
 pg_line_collidepoint(pgLineObject *self, PyObject *const *args,
                      Py_ssize_t nargs)
 {
-    double Cx = 0, Cy = 0;
+    double px, py;
 
-    if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &Cx, &Cy)) {
-            goto error;
-        }
-    }
-    else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &Cx) ||
-            !pg_DoubleFromObj(args[1], &Cy)) {
-            goto error;
-        }
-    }
-    else {
-        goto error;
+    if (!pg_TwoDoublesFromFastcallArgs(args, nargs, &px, &py)) {
+        return RAISE(PyExc_TypeError,
+                     "Line.collidepoint requires a point or PointLike object");
     }
 
-    return PyBool_FromLong(pgCollision_LinePoint(&self->line, Cx, Cy));
-
-error:
-    return RAISE(PyExc_TypeError,
-                 "collidepoint requires a point or PointLike object");
+    return PyBool_FromLong(pgCollision_LinePoint(&self->line, px, py));
 }
 
 static PyObject *
@@ -480,49 +466,24 @@ pg_line_collideswith(pgLineObject *self, PyObject *arg)
 static PyObject *
 pg_line_move(pgLineObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
-    double Dx = 0, Dy = 0;
+    double Dx, Dy;
 
-    if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &Dx, &Dy)) {
-            goto error;
-        }
-    }
-    else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &Dx) ||
-            !pg_DoubleFromObj(args[1], &Dy)) {
-            goto error;
-        }
-    }
-    else {
-        goto error;
+    if (!pg_TwoDoublesFromFastcallArgs(args, nargs, &Dx, &Dy)) {
+        return RAISE(PyExc_TypeError, "move requires a pair of numbers");
     }
 
     return _pg_line_subtype_new4(Py_TYPE(self), self->line.x1 + Dx,
                                  self->line.y1 + Dy, self->line.x2 + Dx,
                                  self->line.y2 + Dy);
-
-error:
-    return RAISE(PyExc_TypeError, "move requires a pair of numbers");
 }
 
 static PyObject *
 pg_line_move_ip(pgLineObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
-    double Dx = 0, Dy = 0;
+    double Dx, Dy;
 
-    if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &Dx, &Dy)) {
-            goto error;
-        }
-    }
-    else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &Dx) ||
-            !pg_DoubleFromObj(args[1], &Dy)) {
-            goto error;
-        }
-    }
-    else {
-        goto error;
+    if (!pg_TwoDoublesFromFastcallArgs(args, nargs, &Dx, &Dy)) {
+        return RAISE(PyExc_TypeError, "move_ip requires a pair of numbers");
     }
 
     self->line.x1 += Dx;
@@ -531,9 +492,6 @@ pg_line_move_ip(pgLineObject *self, PyObject *const *args, Py_ssize_t nargs)
     self->line.y2 += Dy;
 
     Py_RETURN_NONE;
-
-error:
-    return RAISE(PyExc_TypeError, "move_ip requires a pair of numbers");
 }
 
 static struct PyMethodDef pg_line_methods[] = {

--- a/src_c/polygon.c
+++ b/src_c/polygon.c
@@ -390,21 +390,10 @@ pg_polygon_copy(pgPolygonObject *self, PyObject *_null)
 static PyObject *
 pg_polygon_move(pgPolygonObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
-    double Dx = 0.0, Dy = 0.0;
+    double Dx, Dy;
 
-    if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &Dx, &Dy)) {
-            goto error;
-        }
-    }
-    else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &Dx) ||
-            !pg_DoubleFromObj(args[1], &Dy)) {
-            goto error;
-        }
-    }
-    else {
-        goto error;
+    if (!pg_TwoDoublesFromFastcallArgs(args, nargs, &Dx, &Dy)) {
+        return RAISE(PyExc_TypeError, "move requires a pair of numbers");
     }
 
     double *verts = PyMem_New(double, self->polygon.verts_num * 2);
@@ -428,63 +417,36 @@ pg_polygon_move(pgPolygonObject *self, PyObject *const *args, Py_ssize_t nargs)
     }
 
     return tmp;
-error:
-    return RAISE(PyExc_TypeError, "move requires a pair of numbers");
 }
 
 static PyObject *
 pg_polygon_move_ip(pgPolygonObject *self, PyObject *const *args,
                    Py_ssize_t nargs)
 {
-    double Dx = 0.0, Dy = 0.0;
+    double Dx, Dy;
 
-    if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &Dx, &Dy)) {
-            goto error;
-        }
-    }
-    else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &Dx) ||
-            !pg_DoubleFromObj(args[1], &Dy)) {
-            goto error;
-        }
-    }
-    else {
-        goto error;
+    if (!pg_TwoDoublesFromFastcallArgs(args, nargs, &Dx, &Dy)) {
+        return RAISE(PyExc_TypeError, "move_ip requires a pair of numbers");
     }
 
     _pg_move_polygon_helper(&(self->polygon), Dx, Dy);
-    Py_RETURN_NONE;
 
-error:
-    return RAISE(PyExc_TypeError, "move requires a pair of numbers");
+    Py_RETURN_NONE;
 }
 
 static PyObject *
 pg_polygon_collidepoint(pgPolygonObject *self, PyObject *const *args,
                         Py_ssize_t nargs)
 {
-    double x, y;
+    double px, py;
 
-    if (nargs == 1) {
-        if (!pg_TwoDoublesFromObj(args[0], &x, &y)) {
-            goto error;
-        }
-    }
-    else if (nargs == 2) {
-        if (!pg_DoubleFromObj(args[0], &x) || !pg_DoubleFromObj(args[1], &y)) {
-            goto error;
-        }
-    }
-    else {
-        goto error;
+    if (!pg_TwoDoublesFromFastcallArgs(args, nargs, &px, &py)) {
+        return RAISE(
+            PyExc_TypeError,
+            "Polygon.collidepoint requires a point or PointLike object");
     }
 
-    return PyBool_FromLong(pgCollision_PolygonPoint(&self->polygon, x, y));
-
-error:
-    return RAISE(PyExc_TypeError,
-                 "collidepoint requires a point or PointLike object");
+    return PyBool_FromLong(pgCollision_PolygonPoint(&self->polygon, px, py));
 }
 
 static struct PyMethodDef pg_polygon_methods[] = {


### PR DESCRIPTION
This should address a comment from @Emc2356 in #128. This PR swaps all occurrences of two doubles extraction from the fastcall args with a common inline function. I tested with and without the inline and i noticed that the inline keeps performance way closer to the original, though a touch (approx 1%) slower. This should make our code shorter and more readable and maintainable over time. 