### PR TITLE
Polygon `move()/move_ip()` optimization

### DIFF
--- a/benchmarks/GEOMETRY_polygon_benchmark.py
+++ b/benchmarks/GEOMETRY_polygon_benchmark.py
@@ -73,21 +73,41 @@ copy_tests = [
 ]
 
 move_tests = [
-    ("move 100 tuple int", "po100.move((10, 10))"),
-    ("move 100 tuple float", "po100.move((10.0, 10.0))"),
-    ("move 100 2 int", "po100.move(10, 10)"),
-    ("move 100 2 float", "po100.move(10.0, 10.0)"),
-    ("move 100 2 int", "po100.move(10, 10)"),
-    ("move 100 2 float", "po100.move(10.0, 10.0)"),
+    ("int (x-x)", "po100.move((10, 10))"),
+    ("int (0-x)", "po100.move((0, 10))"),
+    ("int (x-0)", "po100.move((10, 0))"),
+    ("int (0-0)", "po100.move((0, 0))"),
+    ("float (x-x)", "po100.move((10.0, 10.0))"),
+    ("float (0-x)", "po100.move((0.0, 10.0))"),
+    ("float (x-0)", "po100.move((10.0, 0.0))"),
+    ("float (0-0)", "po100.move((0.0, 0.0))"),
+    ("int x-x", "po100.move(10, 10)"),
+    ("int 0-x", "po100.move(0, 10)"),
+    ("int x-0", "po100.move(10, 0)"),
+    ("int 0-0", "po100.move(0, 0)"),
+    ("float x-x", "po100.move(10.0, 10.0)"),
+    ("float 0-x", "po100.move(0.0, 10.0)"),
+    ("float x-0", "po100.move(10.0, 0.0)"),
+    ("float 0-0", "po100.move(0.0, 0.0)"),
 ]
 
 move_ip_tests = [
-    ("move_ip 100 tuple int", "po100.move_ip((10, 10))"),
-    ("move_ip 100 tuple float", "po100.move_ip((10.0, 10.0))"),
-    ("move_ip 100 2 int", "po100.move_ip(10, 10)"),
-    ("move_ip 100 2 float", "po100.move_ip(10.0, 10.0)"),
-    ("move_ip 100 2 int", "po100.move_ip(10, 10)"),
-    ("move_ip 100 2 float", "po100.move_ip(10.0, 10.0)"),
+    ("int (x-x)", "po100.move_ip((10, 10))"),
+    ("int (0-x)", "po100.move_ip((0, 10))"),
+    ("int (x-0)", "po100.move_ip((10, 0))"),
+    ("int (0-0)", "po100.move_ip((0, 0))"),
+    ("float (x-x)", "po100.move_ip((10.0, 10.0))"),
+    ("float (0-x)", "po100.move_ip((0.0, 10.0))"),
+    ("float (x-0)", "po100.move_ip((10.0, 0.0))"),
+    ("float (0-0)", "po100.move_ip((0.0, 0.0))"),
+    ("int x-x", "po100.move_ip(10, 10)"),
+    ("int 0-x", "po100.move_ip(0, 10)"),
+    ("int x-0", "po100.move_ip(10, 0)"),
+    ("int 0-0", "po100.move_ip(0, 0)"),
+    ("float x-x", "po100.move_ip(10.0, 10.0)"),
+    ("float 0-x", "po100.move_ip(0.0, 10.0)"),
+    ("float x-0", "po100.move_ip(10.0, 0.0)"),
+    ("float 0-0", "po100.move_ip(0.0, 0.0)"),
 ]
 
 rotate_tests = [

--- a/src_c/polygon.c
+++ b/src_c/polygon.c
@@ -62,22 +62,6 @@ _set_polygon_center_coords(pgPolygonBase *polygon)
     return 1;
 }
 
-static int
-_pg_move_polygon_helper(pgPolygonBase *polygon, double dx, double dy)
-{
-    if (!polygon) {
-        return 0;
-    }
-    Py_ssize_t i2;
-    for (i2 = 0; i2 < polygon->verts_num * 2; i2 += 2) {
-        polygon->vertices[i2] += dx;
-        polygon->vertices[i2 + 1] += dy;
-    }
-    polygon->c_x += dx;
-    polygon->c_y += dy;
-    return 1;
-}
-
 static PyObject *
 _pg_polygon_vertices_aslist(pgPolygonBase *poly)
 {
@@ -316,7 +300,7 @@ _pg_polygon_subtype_new2(PyTypeObject *type, double *vertices,
     return (PyObject *)polygon_obj;
 }
 
-static PyObject *
+static pgPolygonObject *
 _pg_polygon_subtype_new2_copy(PyTypeObject *type, pgPolygonBase *polygon)
 {
     /* Copies an existing polygon type. Specifically it allocates new memory
@@ -345,7 +329,7 @@ _pg_polygon_subtype_new2_copy(PyTypeObject *type, pgPolygonBase *polygon)
     polygon_obj->polygon.c_x = polygon->c_x;
     polygon_obj->polygon.c_y = polygon->c_y;
 
-    return (PyObject *)polygon_obj;
+    return polygon_obj;
 }
 
 static PyObject *
@@ -455,36 +439,56 @@ pg_polygon_copy(pgPolygonObject *self, PyObject *_null)
     return pgPolygon_New(&self->polygon);
 }
 
+static void
+_pg_move_polygon_helper(pgPolygonBase *polygon, double dx, double dy)
+{
+    if (!dx && !dy) {
+        return;
+    }
+
+    polygon->c_x += dx;
+    polygon->c_y += dy;
+
+    Py_ssize_t i2;
+    if (dx) {
+        if (dy) {
+            for (i2 = 0; i2 < polygon->verts_num * 2; i2 += 2) {
+                polygon->vertices[i2] += dx;
+                polygon->vertices[i2 + 1] += dy;
+            }
+            return;
+        }
+        for (i2 = 0; i2 < polygon->verts_num * 2; i2 += 2) {
+            polygon->vertices[i2] += dx;
+        }
+        return;
+    }
+
+    if (dy) {
+        for (i2 = 1; i2 < polygon->verts_num * 2; i2 += 2) {
+            polygon->vertices[i2] += dy;
+        }
+    }
+}
+
 static PyObject *
 pg_polygon_move(pgPolygonObject *self, PyObject *const *args, Py_ssize_t nargs)
 {
     double Dx, Dy;
+    pgPolygonObject *ret;
 
     if (!pg_TwoDoublesFromFastcallArgs(args, nargs, &Dx, &Dy)) {
         return RAISE(PyExc_TypeError, "move requires a pair of numbers");
     }
 
-    double *verts = PyMem_New(double, self->polygon.verts_num * 2);
-    if (!verts) {
-        return NULL;
-    }
-    memcpy(verts, self->polygon.vertices,
-           self->polygon.verts_num * 2 * sizeof(double));
-
-    Py_ssize_t i2;
-    for (i2 = 0; i2 < self->polygon.verts_num * 2; i2 += 2) {
-        verts[i2] += Dx;
-        verts[i2 + 1] += Dy;
-    }
-
-    PyObject *tmp = _pg_polygon_subtype_new2_transfer(Py_TYPE(self), verts,
-                                                      self->polygon.verts_num);
-    if (!tmp) {
-        PyMem_Free(verts);
+    ret = _pg_polygon_subtype_new2_copy(Py_TYPE(self), &self->polygon);
+    if (!ret) {
         return NULL;
     }
 
-    return tmp;
+    _pg_move_polygon_helper(&ret->polygon, Dx, Dy);
+
+    return (PyObject *)ret;
 }
 
 static PyObject *
@@ -497,7 +501,7 @@ pg_polygon_move_ip(pgPolygonObject *self, PyObject *const *args,
         return RAISE(PyExc_TypeError, "move_ip requires a pair of numbers");
     }
 
-    _pg_move_polygon_helper(&(self->polygon), Dx, Dy);
+    _pg_move_polygon_helper(&self->polygon, Dx, Dy);
 
     Py_RETURN_NONE;
 }
@@ -520,6 +524,9 @@ pg_polygon_collidepoint(pgPolygonObject *self, PyObject *const *args,
 static void
 _pg_rotate_polygon_helper(pgPolygonBase *poly, double angle)
 {
+    if (angle == 0.0 || fmod(angle, 360.0) == 0.0) {
+        return;
+    }
     double c_x = poly->c_x, c_y = poly->c_y;
     Py_ssize_t i2, verts_num = poly->verts_num;
     double *vertices = poly->vertices;
@@ -596,14 +603,9 @@ pg_polygon_rotate(pgPolygonObject *self, PyObject *arg)
                      "Invalid angle parameter, must be numeric");
     }
 
-    if (!(ret = (pgPolygonObject *)_pg_polygon_subtype_new2_copy(
-              Py_TYPE(self), &self->polygon))) {
+    ret = _pg_polygon_subtype_new2_copy(Py_TYPE(self), &self->polygon);
+    if (!ret) {
         return NULL;
-    }
-
-    if (angle == 0.0 || fmod(angle, 360.0) == 0.0) {
-        /* No rotation, return a copy */
-        return (PyObject *)ret;
     }
 
     _pg_rotate_polygon_helper(&ret->polygon, angle);
@@ -619,11 +621,6 @@ pg_polygon_rotate_ip(pgPolygonObject *self, PyObject *arg)
     if (!pg_DoubleFromObj(arg, &angle)) {
         return RAISE(PyExc_TypeError,
                      "Invalid angle parameter, must be numeric");
-    }
-
-    if (angle == 0.0 || fmod(angle, 360.0) == 0.0) {
-        /* No rotation, return None immediately */
-        Py_RETURN_NONE;
     }
 
     _pg_rotate_polygon_helper(&self->polygon, angle);

--- a/src_c/polygon.c
+++ b/src_c/polygon.c
@@ -333,31 +333,6 @@ _pg_polygon_subtype_new2_copy(PyTypeObject *type, pgPolygonBase *polygon)
 }
 
 static PyObject *
-_pg_polygon_subtype_new2_transfer(PyTypeObject *type, double *vertices,
-                                  Py_ssize_t verts_num)
-{
-    pgPolygonObject *polygon_obj =
-        (pgPolygonObject *)pgPolygon_Type.tp_new(type, NULL, NULL);
-
-    if (!polygon_obj) {
-        return NULL;
-    }
-
-    if (verts_num < 3 || !vertices) {
-        /*A polygon requires 3 or more vertices*/
-        Py_DECREF(polygon_obj);
-        return NULL;
-    }
-
-    polygon_obj->polygon.vertices = vertices;
-    polygon_obj->polygon.verts_num = verts_num;
-
-    _set_polygon_center_coords(&(polygon_obj->polygon));
-
-    return (PyObject *)polygon_obj;
-}
-
-static PyObject *
 pg_polygon_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     pgPolygonObject *self = (pgPolygonObject *)type->tp_alloc(type, 0);

--- a/test/test_polygon.py
+++ b/test/test_polygon.py
@@ -439,8 +439,8 @@ class PolygonTypeTest(unittest.TestCase):
         self.assertEqual(repr(polygon), p_repr)
         self.assertEqual(polygon.__repr__(), p_repr)
 
-    def test_move(self):
-        """Checks whether polygon moved correctly."""
+    def test_move_xy(self):
+        """Checks whether polygon move function works correctly with an x-y pair."""
         poly = Polygon(_some_vertices.copy())
         center_x = poly.c_x
         center_y = poly.c_y
@@ -458,6 +458,46 @@ class PolygonTypeTest(unittest.TestCase):
         self.assertNotEqual(poly.vertices, new_poly.vertices)
         self.assertEqual(poly.vertices, _some_vertices)
         self.assertAlmostEqual(new_poly.c_x, center_x + 10.0)
+        self.assertAlmostEqual(new_poly.c_y, center_y + 10.0)
+
+    def test_move_x(self):
+        """Checks whether polygon move function works correctly with an x component."""
+        poly = Polygon(_some_vertices.copy())
+        center_x = poly.c_x
+        center_y = poly.c_y
+
+        new_poly = poly.move(10.0, 0.0)
+        vertices = _some_vertices.copy()
+
+        vertices = [list(vertex) for vertex in vertices]
+        for vertex in vertices:
+            vertex[0] += 10.0
+        vertices = [tuple(vertex) for vertex in vertices]
+
+        self.assertEqual(vertices, new_poly.vertices)
+        self.assertNotEqual(poly.vertices, new_poly.vertices)
+        self.assertEqual(poly.vertices, _some_vertices)
+        self.assertAlmostEqual(new_poly.c_x, center_x + 10.0)
+        self.assertAlmostEqual(new_poly.c_y, center_y)
+
+    def test_move_y(self):
+        """Checks whether polygon move function works correctly with a y component."""
+        poly = Polygon(_some_vertices.copy())
+        center_x = poly.c_x
+        center_y = poly.c_y
+
+        new_poly = poly.move(0.0, 10.0)
+        vertices = _some_vertices.copy()
+
+        vertices = [list(vertex) for vertex in vertices]
+        for vertex in vertices:
+            vertex[1] += 10.0
+        vertices = [tuple(vertex) for vertex in vertices]
+
+        self.assertEqual(vertices, new_poly.vertices)
+        self.assertNotEqual(poly.vertices, new_poly.vertices)
+        self.assertEqual(poly.vertices, _some_vertices)
+        self.assertAlmostEqual(new_poly.c_x, center_x)
         self.assertAlmostEqual(new_poly.c_y, center_y + 10.0)
 
     def test_move_inplace(self):
@@ -491,12 +531,41 @@ class PolygonTypeTest(unittest.TestCase):
                 poly.move(*arg)
 
     def test_move_return_type(self):
+        """Tests whether the move function returns a Polygon type/subtype object"""
+        move_amounts = [
+            (1, 1),
+            (0, 1),
+            (1, 0),
+            (0, 0),
+            (1.0, 1.0),
+            (0.0, 1.0),
+            (1.0, 0.0),
+            (0.0, 0.0),
+            (-1, -1),
+            (0, -1),
+            (-1, 0),
+            (-1.0, -1.0),
+            (0.0, -1.0),
+            (-1.0, 0.0),
+        ]
+
         poly = Polygon(_some_vertices.copy())
 
-        self.assertIsInstance(poly.move(1, 1), Polygon)
+        for move_amount in move_amounts:
+            self.assertIsInstance(poly.move(*move_amount), Polygon)
+            self.assertIsInstance(poly.move(move_amount), Polygon)
 
-    def test_move_ip(self):
-        """Ensures that the vertices are moved correctly"""
+        class TestPolygon(Polygon):
+            pass
+
+        polysub = TestPolygon(_some_vertices.copy())
+
+        for move_amount in move_amounts:
+            self.assertIsInstance(polysub.move(*move_amount), TestPolygon)
+            self.assertIsInstance(polysub.move(move_amount), TestPolygon)
+
+    def test_move_ip_xy(self):
+        """Checks whether polygon move_ip function works correctly with an x-y pair."""
         vertices = _some_vertices.copy()
         poly = Polygon(vertices)
         center_x = poly.c_x
@@ -511,6 +580,40 @@ class PolygonTypeTest(unittest.TestCase):
 
         self.assertEqual(poly.vertices, vertices)
         self.assertEqual(poly.c_x, center_x + 10.0)
+        self.assertEqual(poly.c_y, center_y + 10.0)
+
+    def test_move_ip_x(self):
+        """Checks whether polygon move_ip function works correctly with an x component."""
+        vertices = _some_vertices.copy()
+        poly = Polygon(vertices)
+        center_x = poly.c_x
+        center_y = poly.c_y
+
+        poly.move_ip(10.0, 0.0)
+        vertices = [list(vertex) for vertex in vertices]
+        for vertex in vertices:
+            vertex[0] += 10.0
+        vertices = [tuple(vertex) for vertex in vertices]
+
+        self.assertEqual(poly.vertices, vertices)
+        self.assertEqual(poly.c_x, center_x + 10.0)
+        self.assertEqual(poly.c_y, center_y)
+
+    def test_move_ip_y(self):
+        """Checks whether polygon move_ip function works correctly with a y component."""
+        vertices = _some_vertices.copy()
+        poly = Polygon(vertices)
+        center_x = poly.c_x
+        center_y = poly.c_y
+
+        poly.move_ip(0.0, 10.0)
+        vertices = [list(vertex) for vertex in vertices]
+        for vertex in vertices:
+            vertex[1] += 10.0
+        vertices = [tuple(vertex) for vertex in vertices]
+
+        self.assertEqual(poly.vertices, vertices)
+        self.assertEqual(poly.c_x, center_x)
         self.assertEqual(poly.c_y, center_y + 10.0)
 
     def test_move_ip_inplace(self):
@@ -528,9 +631,38 @@ class PolygonTypeTest(unittest.TestCase):
         self.assertEqual(poly.c_y, center_y)
 
     def test_move_ip_return_type(self):
+        """Tests whether the move_ip function returns a Polygon type/subtype object"""
+        move_amounts = [
+            (1, 1),
+            (0, 1),
+            (1, 0),
+            (0, 0),
+            (1.0, 1.0),
+            (0.0, 1.0),
+            (1.0, 0.0),
+            (0.0, 0.0),
+            (-1, -1),
+            (0, -1),
+            (-1, 0),
+            (-1.0, -1.0),
+            (0.0, -1.0),
+            (-1.0, 0.0),
+        ]
+
         poly = Polygon(_some_vertices.copy())
 
-        self.assertEqual(type(poly.move_ip(0, 0)), type(None))
+        for move_amount in move_amounts:
+            self.assertEqual(type(poly.move_ip(*move_amount)), type(None))
+            self.assertEqual(type(poly.move_ip(move_amount)), type(None))
+
+        class TestPolygon(Polygon):
+            pass
+
+        polysub = TestPolygon(_some_vertices.copy())
+
+        for move_amount in move_amounts:
+            self.assertEqual(type(polysub.move_ip(*move_amount)), type(None))
+            self.assertEqual(type(polysub.move_ip(move_amount)), type(None))
 
     def test_move_ip_invalid_args(self):
         """tests if the function correctly handles incorrect types as parameters"""


### PR DESCRIPTION
**Changes:**
- Revisions to the move and move_ip functions to make them more efficient
- Changes to the rotate functions to improve their implementation
- Removed unnecessary center recalculation in the move function (O(N) to O(1))
- Optimized vertices movement calculation by separating cases of movement into x-y, x-0, and 0-y
- Made move and move_ip of (0, 0) O(1) by adding a check and exiting early
- Added more tests and expanded the benchmark suite
- 44.5% improvement in total suite test time for move and move_ip
- deleted `_pg_polygon_subtype_new2_transfer` function

**Results:**

OLD
```
MOVE
==================================================
|    Name     |  Total  |  Mean  |  Std Dev  |
|-------------|---------|--------|-----------|
|  int (x-x)  | 2930.6  | 293.06 |   2.49    |
|  int (0-x)  | 2991.34 | 299.13 |   3.68    |
|  int (x-0)  | 2994.74 | 299.47 |   9.76    |
|  int (0-0)  | 3037.62 | 303.76 |   9.09    |
| float (x-x) | 2877.24 | 287.72 |   8.15    |
| float (0-x) | 2855.68 | 285.57 |   3.97    |
| float (x-0) | 2827.28 | 282.73 |   0.94    |
| float (0-0) | 2839.2  | 283.92 |   1.84    |
|   int x-x   | 3014.74 | 301.47 |   1.46    |
|   int 0-x   | 3036.65 | 303.67 |   2.35    |
|   int x-0   | 3028.46 | 302.85 |   1.12    |
|   int 0-0   | 3060.82 | 306.08 |   3.35    |
|  float x-x  | 2856.38 | 285.64 |    2.3    |
|  float 0-x  | 2867.31 | 286.73 |   5.36    |
|  float x-0  | 2809.42 | 280.94 |   1.83    |
|  float 0-0  | 2838.82 | 283.88 |   1.94    |

--------------------------------------------------
Group Mean: 292.91
Group Total: 46866.3
Group Standard Deviation: 8.81
Group Median: 290.39



MOVE_IP
==================================================
|    Name     |  Total  |  Mean  |  Std Dev  |
|-------------|---------|--------|-----------|
|  int (x-x)  | 1409.16 | 140.92 |   1.68    |
|  int (0-x)  | 1417.64 | 141.76 |    2.5    |
|  int (x-0)  | 1427.67 | 142.77 |   0.66    |
|  int (0-0)  | 1389.63 | 138.96 |   0.39    |
| float (x-x) | 1197.47 | 119.75 |   1.13    |
| float (0-x) | 1198.47 | 119.85 |   1.13    |
| float (x-0) | 1189.53 | 118.95 |   0.84    |
| float (0-0) | 1195.2  | 119.52 |   1.11    |
|   int x-x   | 1423.26 | 142.33 |   1.21    |
|   int 0-x   | 1457.86 | 145.79 |   0.81    |
|   int x-0   | 1454.15 | 145.42 |    0.5    |
|   int 0-0   | 1424.81 | 142.48 |   0.63    |
|  float x-x  | 1231.07 | 123.11 |   1.02    |
|  float 0-x  | 1228.25 | 122.82 |   0.65    |
|  float x-0  | 1240.78 | 124.08 |   1.71    |
|  float 0-0  | 1230.68 | 123.07 |   0.65    |

--------------------------------------------------
Group Mean: 131.97
Group Total: 21115.64
Group Standard Deviation: 10.77
Group Median: 131.52
_____________________________________

Test suite total time: 67981.94 ms
```

NEW
```
MOVE
==================================================
|    Name     |  Total  |  Mean  |  Std Dev  |
|-------------|---------|--------|-----------|
|  int (x-x)  | 2385.97 | 238.6  |   2.18    |
|  int (0-x)  | 2134.23 | 213.42 |   1.41    |
|  int (x-0)  | 2146.59 | 214.66 |   5.95    |
|  int (0-0)  | 1481.07 | 148.11 |   1.14    |
| float (x-x) | 2225.82 | 222.58 |   1.62    |
| float (0-x) | 1974.41 | 197.44 |   1.18    |
| float (x-0) | 1976.15 | 197.61 |   0.63    |
| float (0-0) | 1348.46 | 134.85 |   1.24    |
|   int x-x   | 2508.33 | 250.83 |   2.42    |
|   int 0-x   | 2415.62 | 241.56 |   17.28   |
|   int x-0   | 2270.54 | 227.05 |   5.13    |
|   int 0-0   | 1600.87 | 160.09 |    1.3    |
|  float x-x  | 2274.38 | 227.44 |   1.17    |
|  float 0-x  |  2048   | 204.8  |   5.01    |
|  float x-0  | 2059.87 | 205.99 |    6.6    |
|  float 0-0  | 1395.98 | 139.6  |   2.15    |

--------------------------------------------------
Group Mean: 201.54
Group Total: 32246.29
Group Standard Deviation: 35.71
Group Median: 209.71



MOVE_IP
==================================================
|    Name     |  Total  |  Mean  |  Std Dev  |
|-------------|---------|--------|-----------|
|  int (x-x)  | 1370.87 | 137.09 |   1.98    |
|  int (0-x)  | 1061.81 | 106.18 |   1.35    |
|  int (x-0)  | 1065.33 | 106.53 |   3.04    |
|  int (0-0)  | 491.46  | 49.15  |   2.81    |
| float (x-x) | 1233.32 | 123.33 |   0.74    |
| float (0-x) |  902.5  | 90.25  |   0.64    |
| float (x-0) | 903.81  | 90.38  |   0.83    |
| float (0-0) | 330.78  | 33.08  |    0.7    |
|   int x-x   | 1379.81 | 137.98 |   1.62    |
|   int 0-x   | 1064.35 | 106.44 |     1     |
|   int x-0   | 1061.7  | 106.17 |   1.64    |
|   int 0-0   | 488.12  | 48.81  |   1.45    |
|  float x-x  | 1232.64 | 123.26 |   0.53    |
|  float 0-x  | 922.29  | 92.23  |   0.76    |
|  float x-0  | 936.32  | 93.63  |   1.17    |
|  float 0-0  | 354.65  | 35.46  |   0.58    |

--------------------------------------------------
Group Mean: 92.5
Group Total: 14799.76
Group Standard Deviation: 32.88
Group Median: 99.9
_____________________________________

Test suite total time: 47046.05 ms
```
