### PR TITLE
moved all PI related constants to geometry.h

### DIFF
--- a/src_c/circle.c
+++ b/src_c/circle.c
@@ -7,9 +7,6 @@
 #include <stddef.h>
 #include <math.h>
 
-#define PI 3.14159265358979323846264
-#define TAU 6.28318530717958647692528
-
 static int
 pg_circle_init(pgCircleObject *, PyObject *, PyObject *);
 
@@ -467,7 +464,6 @@ pg_circle_contains(pgCircleObject *self, PyObject *arg)
     return PyBool_FromLong(result);
 }
 
-
 static struct PyMethodDef pg_circle_methods[] = {
     {"collidecircle", (PyCFunction)pg_circle_collidecircle, METH_FASTCALL,
      NULL},
@@ -671,7 +667,7 @@ pg_circle_setcenter(pgCircleObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_circle_getarea(pgCircleObject *self, void *closure)
 {
-    return PyFloat_FromDouble(PI * self->circle.r_sqr);
+    return PyFloat_FromDouble(M_PI * self->circle.r_sqr);
 }
 
 static int
@@ -692,7 +688,7 @@ pg_circle_setarea(pgCircleObject *self, PyObject *value, void *closure)
         return -1;
     }
 
-    self->circle.r_sqr = area / PI;
+    self->circle.r_sqr = area / M_PI;
     self->circle.r = sqrt(self->circle.r_sqr);
 
     return 0;
@@ -701,7 +697,7 @@ pg_circle_setarea(pgCircleObject *self, PyObject *value, void *closure)
 static PyObject *
 pg_circle_getcircumference(pgCircleObject *self, void *closure)
 {
-    return PyFloat_FromDouble(TAU * self->circle.r);
+    return PyFloat_FromDouble(M_TWOPI * self->circle.r);
 }
 
 static int
@@ -724,7 +720,7 @@ pg_circle_setcircumference(pgCircleObject *self, PyObject *value,
         return -1;
     }
 
-    self->circle.r = circumference / TAU;
+    self->circle.r = circumference / M_TWOPI;
     self->circle.r_sqr = self->circle.r * self->circle.r;
 
     return 0;

--- a/src_c/geometry.c
+++ b/src_c/geometry.c
@@ -42,15 +42,15 @@ _pg_extract_ray_from_object_fastcall(PyObject *const *args, Py_ssize_t nargs,
         }
 
         if (PyNumber_Check(args[1])) {
-            double angle, rad_angle;
+            double angle;
             if (!pg_DoubleFromObj(args[1], &angle)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "Invalid ray angle value, must be numeric");
                 return 0;
             }
-            rad_angle = DEG_TO_RAD(angle);
-            line->x2 = line->x1 - cos(rad_angle);
-            line->y2 = line->y1 - sin(rad_angle);
+            angle = DEG_TO_RAD(angle);
+            line->x2 = line->x1 - cos(angle);
+            line->y2 = line->y1 - sin(angle);
         }
         else if (!pg_TwoDoublesFromObj(args[1], &line->x2, &line->y2)) {
             PyErr_SetString(PyExc_TypeError,

--- a/src_c/geometry.c
+++ b/src_c/geometry.c
@@ -42,15 +42,15 @@ _pg_extract_ray_from_object_fastcall(PyObject *const *args, Py_ssize_t nargs,
         }
 
         if (PyNumber_Check(args[1])) {
-            double angle;
+            double angle, rad_angle;
             if (!pg_DoubleFromObj(args[1], &angle)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "Invalid ray angle value, must be numeric");
                 return 0;
             }
-
-            line->x2 = line->x1 - cos(angle * PI / 180);
-            line->y2 = line->y1 - sin(angle * PI / 180);
+            rad_angle = DEG_TO_RAD(angle);
+            line->x2 = line->x1 - cos(rad_angle);
+            line->y2 = line->y1 - sin(rad_angle);
         }
         else if (!pg_TwoDoublesFromObj(args[1], &line->x2, &line->y2)) {
             PyErr_SetString(PyExc_TypeError,
@@ -194,7 +194,7 @@ geometry_regular_polygon(PyObject *_null, PyObject *const *args,
             return RAISE(PyExc_TypeError,
                          "the forth parameter must be a number");
         }
-        angle *= PI / 180.0;
+        angle = DEG_TO_RAD(angle);
     }
 
     double *vertices = PyMem_New(double, sides * 2);
@@ -204,7 +204,7 @@ geometry_regular_polygon(PyObject *_null, PyObject *const *args,
     }
 
     Py_ssize_t loop;
-    double fac = TAU / sides;
+    double fac = M_TWOPI / sides;
 
     /*If the number of sides is even, mirror the vertices*/
     if (sides % 2 == 0) {
@@ -362,4 +362,3 @@ MODINIT_DEFINE(geometry)
     }
     return module;
 }
-     

--- a/src_c/include/geometry.h
+++ b/src_c/include/geometry.h
@@ -118,12 +118,14 @@ pgPolygon_FromObject(PyObject *obj, pgPolygonBase *out);
 
 /* Functions */
 
+/* Converts degrees to radians */
 static PG_FORCE_INLINE double
 DEG_TO_RAD(double deg)
 {
     return deg * M_PI_QUO_180;
 }
 
+/* Converts radians to degrees */
 static PG_FORCE_INLINE double
 RAD_TO_DEG(double rad)
 {

--- a/src_c/include/geometry.h
+++ b/src_c/include/geometry.h
@@ -84,4 +84,50 @@ pgPolygon_FromObject(PyObject *obj, pgPolygonBase *out);
 #define pgLine_Check(o) ((o)->ob_type == &pgLine_Type)
 #define pgPolygon_Check(o) ((o)->ob_type == &pgPolygon_Type)
 
+/* Constants */
+
+/* PI */
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+/* 2PI */
+#ifndef M_TWOPI
+#define M_TWOPI 6.28318530717958647692
+#endif
+
+/* PI/2 */
+#ifndef M_PI_QUO_2
+#define M_PI_QUO_2 1.57079632679489661923
+#endif
+
+/* PI/4 */
+#ifndef M_PI_QUO_4
+#define M_PI_QUO_4 0.78539816339744830962
+#endif
+
+/* PI/180 */
+#ifndef M_PI_QUO_180
+#define M_PI_QUO_180 0.01745329251994329577
+#endif
+
+/* 180/PI */
+#ifndef M_180_QUO_PI
+#define M_180_QUO_PI 57.29577951308232087680
+#endif
+
+/* Functions */
+
+static PG_FORCE_INLINE double
+DEG_TO_RAD(double deg)
+{
+    return deg * M_PI_QUO_180;
+}
+
+static PG_FORCE_INLINE double
+RAD_TO_DEG(double rad)
+{
+    return rad * M_180_QUO_PI;
+}
+
 #endif /* ~_GEOMETRY_H */

--- a/src_c/line.c
+++ b/src_c/line.c
@@ -7,14 +7,6 @@
 #include <stddef.h>
 #include <math.h>
 
-#ifndef PI
-#define PI 3.14159265358979323846264
-#endif
-
-#ifndef RAD_TO_DEG
-#define RAD_TO_DEG(x) (x * 180 / PI)
-#endif
-
 #define IS_LINE_VALID(line) (line->x1 != line->x2 || line->y1 != line->y2)
 
 static double

--- a/src_c/polygon.c
+++ b/src_c/polygon.c
@@ -7,18 +7,6 @@
 #include <stddef.h>
 #include <math.h>
 
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
-#ifndef M_PI_QUO_2
-#define M_PI_QUO_2 1.57079632679489661923
-#endif
-
-#ifndef M_TWOPI
-#define M_TWOPI 6.28318530717958647692
-#endif
-
 static PG_FORCE_INLINE double *
 _pg_new_vertices_from_polygon(pgPolygonBase *polygon)
 {
@@ -524,7 +512,7 @@ _pg_rotate_polygon_helper(pgPolygonBase *poly, double angle)
     double *vertices = poly->vertices;
 
     /*convert the angle to radians*/
-    double angle_rad = angle * M_PI / 180.0;
+    double angle_rad = DEG_TO_RAD(angle);
 
     if (fmod(angle_rad, M_PI_QUO_2) != 0.0) {
         /* handle the general angle case that's not 90, 180 or 270 degrees */
@@ -816,7 +804,7 @@ _pg_distance(double x1, double y1, double x2, double y2)
 }
 
 static PyObject *
-pg_polygon_get_perimeter(pgPolygonObject *self, void *closure) 
+pg_polygon_get_perimeter(pgPolygonObject *self, void *closure)
 {
     double perimeter = 0;
     double *vertices = self->polygon.vertices;

--- a/test/test_line.py
+++ b/test/test_line.py
@@ -356,7 +356,7 @@ class LineTypeTest(unittest.TestCase):
         line = Line(45.0, 32.0, 94.0, 67.0)
         self.assertEqual(line.angle, expected_angle)
 
-        expected_angle = -53.88065915052026
+        expected_angle = -53.88065915052025
         line = Line(544.0, 235.0, 382.0, 13.0)
         self.assertEqual(line.angle, expected_angle)
 


### PR DESCRIPTION
I consolidated all PI-related defines in the geometry.h header to reduce duplication in the poly, circle, and line modules. I also standardized the naming conventions and made necessary fixes and refactoring to support the changes. The changes I made include:

- Using "M_" to prefix all PI-related constants (e.g. `M_PI`, `M_TWOPI`)
- Replacing `DEG_TO_RAD` and `RAD_TO_DEG` macros with static inline functions
- Adding new constants: `M_PI_QUO_4` (PI / 4), `M_PI_QUO_180` (PI / 180), and `M_180_QUO_PI` (180 / PI)
- Correcting a test
- Updating all PI-related references to use the new constants and functions